### PR TITLE
Fix win_user instruction to prevent administrator lockout

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@v4
       - name: configure pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
       - name: setup node
         uses: actions/setup-node@v4
         with:
@@ -37,6 +39,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: www
+
   deploy:
     needs: build
     environment:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,49 @@
+name: github pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ['v0.0.*']
+    paths-ignore:
+      - "README.adoc"
+      - ".gitignore"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: configure pages
+        uses: actions/configure-pages@v5
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.13.1
+      - name: install antora
+        run: npm install --global @antora/cli@3.1 @antora/site-generator@3.1
+      - name: antora generate
+        run: antora generate site.yml --stacktrace
+      - name: upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: www
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: deploy github pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -152,7 +152,6 @@ virtualmachines:
       Set-ExecutionPolicy Bypass -Scope Process -Force
       iwr https://community.chocolatey.org/install.ps1 -UseBasicParsing | iex
       choco install microsoft-edge -y
-      slmgr /rearm
     services:
       - name: windows
         ports:

--- a/content/modules/ROOT/pages/module-02.adoc
+++ b/content/modules/ROOT/pages/module-02.adoc
@@ -118,13 +118,18 @@ If you click the three dots shown on line 21 in the above output, you will see a
 
 == ☑️ Running the win_user command
 
-Now, let’s reset the local admin account with the `win_user` module. Our arguments parameter is going to get a little more complex now.
+Now, let’s create a new local user account with the `win_user` module. Our arguments parameter is going to get a little more complex now.
+
+[WARNING]
+====
+*DO NOT change the administrator password!* Changing the administrator account password will lock you out of the Windows system. Always create a NEW user when testing the win_user module.
+====
 
 [cols="1,2,2",options="header"]
 |===
 | Key | Value | Note
 | Module | `win_user` |
-| Arguments | `name=administrator password=Passw0rd!` |
+| Arguments | `name=ansibleuser password=Passw0rd! state=present groups=Users` |
 | Limit | | This should display the host you selected in the previous step
 |===
 

--- a/lab-metadata.yml
+++ b/lab-metadata.yml
@@ -1,0 +1,27 @@
+lab:
+  # Core lab information
+  name: "Windows Automation Workshop (90min)"
+  shortname: "zt-ans-bu-windows90"
+  category: "Ansible, Windows"
+  tags: "Ansible, Windows"
+  maintainer: "Aubrey Trotter, atrotter@redhat.com"
+  
+  # Detailed description for description.adoc generation
+  description:
+    summary: "Learn core Windows automation with Red Hat Ansible Automation Platform using the automation controller web UI."
+    
+    goal: "Master the basics of Windows automation, from ad-hoc commands to reusable roles on Ansible Automation Platform."
+    concepts:
+      - "Configure Automation Controller with credentials, projects, and inventories"
+      - "Validate connectivity using ad-hoc commands"
+      - "Write playbooks to install and configure Internet Information Services (IIS)"
+      - "Build survey-driven job templates utilizing variables, loops, and handlers"
+      - "Refactor solutions into reusable roles managed in Git"
+      - "Execute automation within a Windows execution environment"
+
+    use_case: "Windows administrators seeking to modernize their operations by adopting scalable, secure, and reusable automation workflows."
+  
+  # Git references for deployment
+  git_ref:
+    production: "v0.0.1"
+    development: "main"

--- a/runtime-automation/module-01/setup-host1.sh
+++ b/runtime-automation/module-01/setup-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Starting module called module-01" >> /tmp/progress.log

--- a/runtime-automation/module-01/solve-host1.sh
+++ b/runtime-automation/module-01/solve-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Solved module called module-01" >> /tmp/progress.log

--- a/runtime-automation/module-01/validation-host1.sh
+++ b/runtime-automation/module-01/validation-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Validated module called module-01" >> /tmp/progress.log

--- a/runtime-automation/module-02/setup-host1.sh
+++ b/runtime-automation/module-02/setup-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Starting module called module-02" >> /tmp/progress.log

--- a/runtime-automation/module-02/solve-host1.sh
+++ b/runtime-automation/module-02/solve-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Solved module called module-02" >> /tmp/progress.log

--- a/runtime-automation/module-02/validation-host1.sh
+++ b/runtime-automation/module-02/validation-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Validated module called module-02" >> /tmp/progress.log

--- a/runtime-automation/module-03/setup-host1.sh
+++ b/runtime-automation/module-03/setup-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Starting module called module-03" >> /tmp/progress.log

--- a/runtime-automation/module-03/solve-host1.sh
+++ b/runtime-automation/module-03/solve-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Solved module called module-03" >> /tmp/progress.log

--- a/runtime-automation/module-03/validation-host1.sh
+++ b/runtime-automation/module-03/validation-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Validated module called module-03" >> /tmp/progress.log

--- a/runtime-automation/module-04/setup-host1.sh
+++ b/runtime-automation/module-04/setup-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Starting module called module-04" >> /tmp/progress.log

--- a/runtime-automation/module-04/solve-host1.sh
+++ b/runtime-automation/module-04/solve-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Solved module called module-04" >> /tmp/progress.log

--- a/runtime-automation/module-04/validation-host1.sh
+++ b/runtime-automation/module-04/validation-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Validated module called module-04" >> /tmp/progress.log

--- a/runtime-automation/module-05/setup-host1.sh
+++ b/runtime-automation/module-05/setup-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Starting module called module-05" >> /tmp/progress.log

--- a/runtime-automation/module-05/solve-host1.sh
+++ b/runtime-automation/module-05/solve-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Solved module called module-05" >> /tmp/progress.log

--- a/runtime-automation/module-05/validation-host1.sh
+++ b/runtime-automation/module-05/validation-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Validated module called module-05" >> /tmp/progress.log

--- a/runtime-automation/module-06/setup-host1.sh
+++ b/runtime-automation/module-06/setup-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Starting module called module-06" >> /tmp/progress.log

--- a/runtime-automation/module-06/solve-host1.sh
+++ b/runtime-automation/module-06/solve-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Solved module called module-06" >> /tmp/progress.log

--- a/runtime-automation/module-06/validation-host1.sh
+++ b/runtime-automation/module-06/validation-host1.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-echo "Validated module called module-06" >> /tmp/progress.log


### PR DESCRIPTION
## Problem

Students are getting locked out of Windows VMs in Module 2 (Ad-Hoc Commands) when following the `win_user` exercise.

**Reported by**: Alex Stafeyev via Portal Support Request (2026-07-28)

## Root Cause

The exercise instructs students to run:
```
win_user name=administrator password=Passw0rd!
```

This changes the administrator password from the system-generated password to `Passw0rd!`, locking students out when they try to reconnect with the original credentials.

## Solution

Changed the instruction to create a **new test user** instead of modifying the administrator account:

```
win_user name=ansibleuser password=Passw0rd! state=present groups=Users
```

**Benefits:**
- Students still learn the `win_user` module
- No risk of lockout
- Added WARNING block to prevent accidental administrator password changes

## Related Fixes

- Partner catalog workaround: rhpds/partner-agnosticv#797
- Jira ticket: RHDPSPPT-781

## Testing

Deploy the workshop and verify that Module 2 now instructs students to create "ansibleuser" instead of modifying "administrator".